### PR TITLE
Close unclosed templates implicitly when a table row is encountered

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -205,7 +205,7 @@ pub fn parse<'a>(
                             &mut state,
                             super::WarningMessage::UnexpectedTableRowSeparatorInsideTemplate,
                         );
-						super::table::parse_inline_token(&mut state);
+						continue;
 					} else {
 						super::template::parse_parameter_separator(&mut state);
 					}
@@ -227,7 +227,7 @@ pub fn parse<'a>(
                             &mut state,
                             super::WarningMessage::UnexpectedTableRowSeparatorInsideTemplate,
                         );
-						super::table::parse_inline_token(&mut state);
+						continue;
 					} else {
 						super::template::parse_template_separator(&mut state);
 					}

--- a/src/warning.rs
+++ b/src/warning.rs
@@ -70,6 +70,9 @@ pub enum WarningMessage {
 
 	/// Useless text in redirect.
 	UselessTextInRedirect,
+
+	/// Unexpected table row separator inside template
+	UnexpectedTableRowSeparatorInsideTemplate,
 }
 
 impl WarningMessage {
@@ -115,6 +118,9 @@ impl WarningMessage {
 			WarningMessage::UselessTextInRedirect => {
 				"Useless text in redirect."
 			}
+			WarningMessage::UnexpectedTableRowSeparatorInsideTemplate => {
+                "Unepexted table row separator inside template. Closing template implicitly"
+            }
 		}
 	}
 }


### PR DESCRIPTION
This is an improvement related to issue #1. It does not solve the exponential time problem in all cases, but allows the library to parse the article "Michael Bryant (actor)" and similarly-formatted articles. I have explained the fix proposal in more detail in a comment on the issue.