### PR TITLE
Add `max_ms` parameter to parse function to limit execution time

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -151,18 +151,28 @@ impl crate::Configuration {
 
 	/// Parses wiki text into structured data with a user defined timeout.
 	#[must_use]
-	pub fn parse_with_timeout<'a>(&self, wiki_text: &'a str, max_duration: std::time::Duration) -> Result<crate::Output<'a>, crate::parse::ParseError> {
+	pub fn parse_with_timeout<'a>(
+		&self,
+		wiki_text: &'a str,
+		max_duration: std::time::Duration,
+	) -> Result<crate::Output<'a>, crate::parse::ParseError<'a>> {
 		crate::parse::parse(self, wiki_text, max_duration)
 	}
 	/// Parses wiki text into structured data with a default timeout of 5 seconds.
 	#[must_use]
-	pub fn parse<'a>(&self, wiki_text: &'a str) -> crate::Output<'a> {
-		crate::parse::parse(self, wiki_text, std::time::Duration::from_secs(5)).unwrap()
+	pub fn parse<'a>(
+		&self,
+		wiki_text: &'a str,
+	) -> Result<crate::Output<'a>, crate::parse::ParseError<'a>> {
+		crate::parse::parse(self, wiki_text, std::time::Duration::from_secs(5))
 	}
 	/// Parses wiki text into structured data with no time out.
 	/// This function may run for extremely long lengths of time on certain articles
 	#[must_use]
-	pub fn parse_without_timeout<'a>(&self, wiki_text: &'a str) -> Result<crate::Output<'a>, crate::parse::ParseError> {
+	pub fn parse_without_timeout<'a>(
+		&self,
+		wiki_text: &'a str,
+	) -> Result<crate::Output<'a>, crate::parse::ParseError<'a>> {
 		crate::parse::parse(self, wiki_text, std::time::Duration::ZERO)
 	}
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -151,8 +151,8 @@ impl crate::Configuration {
 
 	/// Parses wiki text into structured data.
 	#[must_use]
-	pub fn parse<'a>(&self, wiki_text: &'a str) -> crate::Output<'a> {
-		crate::parse::parse(self, wiki_text)
+	pub fn parse<'a>(&self, wiki_text: &'a str, max_ms: u128) -> Result<crate::Output<'a>, &'static str> {
+		crate::parse::parse(self, wiki_text, max_ms)
 	}
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -149,10 +149,21 @@ impl crate::Configuration {
 		configuration
 	}
 
-	/// Parses wiki text into structured data.
+	/// Parses wiki text into structured data with a user defined timeout.
 	#[must_use]
-	pub fn parse<'a>(&self, wiki_text: &'a str, max_ms: u128) -> Result<crate::Output<'a>, &'static str> {
-		crate::parse::parse(self, wiki_text, max_ms)
+	pub fn parse_with_timeout<'a>(&self, wiki_text: &'a str, max_duration: std::time::Duration) -> Result<crate::Output<'a>, crate::parse::ParseError> {
+		crate::parse::parse(self, wiki_text, max_duration)
+	}
+	/// Parses wiki text into structured data with a default timeout of 5 seconds.
+	#[must_use]
+	pub fn parse<'a>(&self, wiki_text: &'a str) -> crate::Output<'a> {
+		crate::parse::parse(self, wiki_text, std::time::Duration::from_secs(5)).unwrap()
+	}
+	/// Parses wiki text into structured data with no time out.
+	/// This function may run for extremely long lengths of time on certain articles
+	#[must_use]
+	pub fn parse_without_timeout<'a>(&self, wiki_text: &'a str) -> Result<crate::Output<'a>, crate::parse::ParseError> {
+		crate::parse::parse(self, wiki_text, std::time::Duration::ZERO)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ mod template;
 mod trie;
 mod warning;
 
+
 pub use configuration::ConfigurationSource;
 use configuration::Namespace;
 use state::{OpenNode, OpenNodeType, State};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //!		*Speed\n\
 //!		*Ergonomics\
 //! ";
-//! let result = Configuration::default().parse(wiki_text);
+//! let result = Configuration::default().parse(wiki_text).expect("parsing timed out");
 //! assert!(result.warnings.is_empty());
 //! # let mut found = false;
 //! for node in result.nodes {
@@ -130,9 +130,9 @@ mod template;
 mod trie;
 mod warning;
 
-
 pub use configuration::ConfigurationSource;
 use configuration::Namespace;
+pub use parse::ParseError;
 use state::{OpenNode, OpenNodeType, State};
 use std::{
 	borrow::Cow,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -48,8 +48,8 @@ pub fn parse<'a>(
 			}
 		}
 	}
-	let mut loopCounter = 0;
-	let startTime = std::time::Instant::now();
+	let mut loop_counter = 0;
+	let start_time = std::time::Instant::now();
 
 	crate::line::parse_beginning_of_line(&mut state, None);
 	loop {
@@ -228,14 +228,14 @@ pub fn parse<'a>(
 			}
 		}
 
-		if loopCounter == 10000 {
-			loopCounter = 0;
-			if startTime.elapsed().as_millis() > max_ms {
+		if loop_counter == 10000 {
+			loop_counter = 0;
+			if start_time.elapsed().as_millis() > max_ms {
 				return Err("Max ms exceeded")
 			}
 		}
 
-		loopCounter+=1;
+		loop_counter+=1;
 	}
 	let end_position = state.skip_whitespace_backwards(wiki_text.len());
 	state.flush(end_position);

--- a/src/state.rs
+++ b/src/state.rs
@@ -83,7 +83,7 @@ impl<'a> State<'a> {
 	}
 
 	pub fn get_byte(&self, position: usize) -> Option<u8> {
-		self.wiki_text.as_bytes().get(position).cloned()
+		self.wiki_text.as_bytes().get(position).copied()
 	}
 
 	pub fn push_open_node(

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -84,7 +84,7 @@ fn test_file(path: &str) {
 	let cfg = Configuration::default();
 
 	for case in &mut cases {
-		let res = cfg.parse(&case.case);
+		let res = cfg.parse(&case.case).unwrap();
 		let expected_nodes = res.nodes.to_test_str();
 		let expected_warnings = res.warnings.to_test_str();
 


### PR DESCRIPTION
Solves #4.

I was thinking it's also possible to change the code of `configuration.rs` to the following:

```rust
#[must_use]
	pub fn parse<'a>(&self, wiki_text: &'a str) -> crate::Output<'a> {
		crate::parse::parse(self, wiki_text, 0).unwrap()
	}

	#[must_use]
	pub fn parse_with_timeout<'a>(&self, wiki_text: &'a str, max_ms: u128) -> Result<crate::Output<'a>, &'static str> {
		crate::parse::parse(self, wiki_text, max_ms)
	}
```

and then modify the code I put in `parse.rs` so that if the `max_ms` parameter is 0, no limit is applied. That would mean that people who don't need to use the timeout code won't be affected if it's removed in future. I'm happy to implement that in this fork if it seems like a good idea.