### PR TITLE
feat: use web-time when the wasm feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,11 @@ repository = "https://github.com/soerenmeier/parse-wiki-text-2"
 version = "0.2.0"
 rust-version = "1.90"
 
+[dependencies]
+web-time = { version = "1.1.0", optional = true }
+
 [dev-dependencies]
 clap = { version = "4.0", features = ["derive"] }
+
+[features]
+wasm = ["dep:web-time"]

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -63,6 +63,9 @@ pub fn parse<'a>(
 		}
 	}
 	let mut loop_counter = 0;
+	#[cfg(feature = "wasm")]
+	let start_time = web_time::Instant::now();
+	#[cfg(not(feature = "wasm"))]
 	let start_time = std::time::Instant::now();
 
 	crate::line::parse_beginning_of_line(&mut state, None);


### PR DESCRIPTION
`parse-wiki-text-2` will panic at runtime under WASM as `std::time::Instant` is unavailable. This PR adds a `wasm` feature that substitutes that for `web_time::Instant`, which works identically but uses `wasm-bindgen` behind the scenes. This is feature-gated to avoid dragging in the dependency for non-web users.