### PR TITLE
Fix timeout panic on non-UTF-8-boundary scan positions

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -245,7 +245,7 @@ pub fn parse<'a>(
 		if !max_duration.is_zero() && loop_counter == 10_000 {
 			loop_counter = 0;
 			if start_time.elapsed() > max_duration {
-				state.flush(state.scan_position);
+				state.flush(state.previous_char_boundary(state.scan_position));
 
 				return Err(ParseError::TimedOut {
 					execution_time: start_time.elapsed(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -140,6 +140,10 @@ impl<'a> State<'a> {
 	pub fn skip_whitespace_forwards(&self, position: usize) -> usize {
 		skip_whitespace_forwards(self.wiki_text, position)
 	}
+
+	pub fn previous_char_boundary(&self, position: usize) -> usize {
+		previous_char_boundary(self.wiki_text, position)
+	}
 }
 
 pub fn flush<'a>(
@@ -180,9 +184,26 @@ pub fn skip_whitespace_forwards(wiki_text: &str, position: usize) -> usize {
 	position + non_whitespace_position
 }
 
+fn previous_char_boundary(wiki_text: &str, mut position: usize) -> usize {
+	position = position.min(wiki_text.len());
+	while !wiki_text.is_char_boundary(position) {
+		position -= 1;
+	}
+	position
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn test_previous_char_boundary() {
+		assert_eq!(previous_char_boundary("aн", 0), 0);
+		assert_eq!(previous_char_boundary("aн", 1), 1);
+		assert_eq!(previous_char_boundary("aн", 2), 1);
+		assert_eq!(previous_char_boundary("aн", 3), 3);
+		assert_eq!(previous_char_boundary("aн", 4), 3);
+	}
 
 	#[test]
 	fn test_skip_whitespace_backwards() {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -30,3 +30,18 @@ fn issue_1() {
 		_ => panic!("expected timeout"),
 	}
 }
+
+#[test]
+fn timeout_while_scanning_multibyte_text_does_not_panic() {
+	let s = "н".repeat(100_000);
+	let result = std::panic::catch_unwind(|| {
+		Configuration::default().parse_with_timeout(&s, Duration::from_nanos(1))
+	});
+
+	let result =
+		result.expect("parser panicked on a non-UTF-8-boundary byte offset");
+	assert!(
+		matches!(result, Err(ParseError::TimedOut { .. })),
+		"expected timeout, got {result:?}"
+	);
+}


### PR DESCRIPTION
>   The parser scans wikitext byte-by-byte, but Rust string slices must start and
>   end on UTF-8 character boundaries. When parsing times out, scan_position can
>   point into the middle of a multibyte character. Flushing at that position then
>   panics while slicing wiki_text.
> 
>   Clamp the timeout flush position back to the previous UTF-8 character boundary
>   before creating partial output.
> 
>   Add a regression test with Cyrillic text and a tiny timeout to ensure timeout
>   handling returns ParseError::TimedOut instead of panicking.
> 

The patch is produced by gpt-5.5 xhigh, I had that issue with my https://gitlab.com/vitaly-zdanevich/wiki2man_on_rust